### PR TITLE
Improved manifest generation. Works only on powerShell 5

### DIFF
--- a/Source/ISHRemote/Build.props
+++ b/Source/ISHRemote/Build.props
@@ -20,5 +20,8 @@
     <MinCLRVersion>4.0</MinCLRVersion>
     <MinDotNetVersion>4.5</MinDotNetVersion>
     <DocPortalLink>https://sdl.github.io/$(ProductName)/</DocPortalLink>
+    <DocPortalLink>https://sdl.github.io/$(ProductName)/</DocPortalLink>
+    <LicenseUri>https://github.com/sdl/$(ProductName)/blob/master/LICENSE.TXT</LicenseUri>
+    <ProjectUri>https://github.com/sdl/$(ProductName)/</ProjectUri>
   </PropertyGroup>
 </Project>

--- a/Source/ISHRemote/Trisoft.ISHRemote/Properties/ModuleManifest.targets
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Properties/ModuleManifest.targets
@@ -24,9 +24,10 @@
       <PowerShellVersion>$(MinPowerShellVersion)</PowerShellVersion>
       <CLRVersion>$(MinCLRVersion)</CLRVersion>
       <DotNetFrameworkVersion>$(MinDotNetVersion)</DotNetFrameworkVersion>
-      <HelpInfoURI>$(DocPortalLink)</HelpInfoURI>
+      <LicenseUri>$(LicenseUri)</LicenseUri>
+      <ProjectUri>$(ProjectUri)</ProjectUri>
       <FormatsToProcessPath>$(ModuleName).Format.ps1xml</FormatsToProcessPath>
     </PropertyGroup>
-    <Exec Command='$(PowerShellExe) -NonInteractive -command "New-ModuleManifest -Path &apos;$(ManifestPath)&apos; -FormatsToProcess &apos;$(FormatsToProcessPath)&apos; -RootModule &apos;$(RootModule)&apos; -NestedModules @($(NestedModules)) -ModuleVersion &apos;$(ModuleVersion)&apos; -Guid &apos;$(Guid)&apos; -Author &apos;$(Author)&apos; -CompanyName &apos;$(CompanyName)&apos; -Copyright &apos;$(Copyright)&apos; -Description &apos;$(Description)&apos; -PowerShellVersion &apos;$(PowerShellVersion)&apos; -ClrVersion &apos;$(CLRVersion)&apos; -DotNetFrameworkVersion &apos;$(DotNetFrameworkVersion)&apos; -HelpInfoURI &apos;$(HelpInfoURI)&apos;"'/>
+    <Exec Command='$(PowerShellExe) -NonInteractive -command "New-ModuleManifest -Path &apos;$(ManifestPath)&apos; -FormatsToProcess &apos;$(FormatsToProcessPath)&apos; -RootModule &apos;$(RootModule)&apos; -NestedModules @($(NestedModules)) -ModuleVersion &apos;$(ModuleVersion)&apos; -Guid &apos;$(Guid)&apos; -Author &apos;$(Author)&apos; -CompanyName &apos;$(CompanyName)&apos; -Copyright &apos;$(Copyright)&apos; -Description &apos;$(Description)&apos; -PowerShellVersion &apos;$(PowerShellVersion)&apos; -ClrVersion &apos;$(CLRVersion)&apos; -DotNetFrameworkVersion &apos;$(DotNetFrameworkVersion)&apos; -HelpInfoURI &apos;$(HelpInfoURI)&apos; -LicenseUri &apos;$(LicenseUri)&apos;  -ProjectUri &apos;$(ProjectUri)&apos;"'/>
   </Target>
 </Project>


### PR DESCRIPTION
Added the `-LicenseUri` and `-ProjectUri` parameters in the manifest generation. This works **only* with PowerShell 5. It is not a restriction when using the module, but only when building it.