### PR TITLE
#99 Get-IshFolderContent should return all versions of objects

### DIFF
--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.Tests.ps1
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.Tests.ps1
@@ -22,12 +22,13 @@ Describe “Get-IshFolderContent" -Tags "Read" {
 	$ishTopicCount = 3
 	for($current=1;$current -le $ishTopicCount;$current++)
 	{
+		# Create topic
 		$ishTopicMetadata = Set-IshMetadataField -IshSession $ishSession -Name "FTITLE" -Level Logical -Value "Topic $current" |
 						    Set-IshMetadataField -IshSession $ishSession -Name "FAUTHOR" -Level Lng -ValueType Element -Value $ishUserAuthor |
 						    Set-IshMetadataField -IshSession $ishSession -Name "FSTATUS" -Level Lng -ValueType Element -Value $ishStatusDraft
 		$ishObject = Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
-
-		Add-IshDocumentObj -IshSession $ishSession -IshFolder $ishFolderTopic -LogicalId $ishObject.IshRef -Version "2" -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
+		# Create extra version
+		Add-IshDocumentObj -IshSession $ishSession -LogicalId $ishObject.IshRef -Version "2" -IshType ISHModule -Lng $ishLng -Metadata $ishTopicMetadata -FileContent $ditaTopicFileContent
 	}
 
 	Context “Get-IshFolderContent ParameterGroup" {
@@ -134,7 +135,7 @@ Describe “Get-IshFolderContent" -Tags "Read" {
 			$ishObjects[0].fstatus.Length -ge 1 | Should Be $true 
 			$ishObjects[0].fstatus_lng_element.StartsWith('VSTATUS') | Should Be $true 
         }
-        It "version_version_value" { 
+        It "ishObjects[0].version_version_value" { 
             # First version
             ($ishobjects | Where-Object version_version_value -eq 1 | Select-Object).Length | Should BeExactly $ishTopicCount 
             # Second version

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.cs
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.cs
@@ -30,11 +30,13 @@ namespace Trisoft.ISHRemote.Cmdlets.Folder
     /// <para type="synopsis">The Get-IshFolderContent cmdlet returns all document objects or publication outputs stored inside a given folder.
     /// You can provide filters to reduce the amount of objects returned, but if you don't provide any:
     /// * The cmdlet will return an object for all the latest versions in all language and resolution for a document object folder
-    /// * The cmdlet will return an object for all the latest versions for all output formats and all language combinations for a publication folder</para>
+    /// * The cmdlet will return an object for all the latest versions for all output formats and all language combinations for a publication folder
+    /// Note: The default value of the VersionFilter is "latest". In order to get all versions, you need to pass an empty string in the VersionFilter.</para>
     /// <para type="description">The Get-IshFolderContent cmdlet returns all document objects or publication outputs stored inside a given folder.
     /// You can provide filters to reduce the amount of objects returned, but if you don't provide any:
     /// * The cmdlet will return an object for all the latest versions in all language and resolution for a document object folder
-    /// * The cmdlet will return an object for all the latest versions for all output formats and all language combinations for a publication folder</para>
+    /// * The cmdlet will return an object for all the latest versions for all output formats and all language combinations for a publication folder.
+    /// Note: The default value of the VersionFilter is "latest". In order to get all versions, you need to pass an empty string in the VersionFilter.</para>
     /// </summary>
     /// <example>
     /// <code>
@@ -66,13 +68,21 @@ namespace Trisoft.ISHRemote.Cmdlets.Folder
     /// <example>
     /// <code>
     /// $ishSession = New-IshSession -WsBaseUrl "https://example.com/ISHWS/" -PSCredential "Admin"
+    /// $metadataFilter = Set-IshMetadataFilterField -Level Lng -Name FSOURCELANGUAGE -FilterOperator Empty
+    /// Get-IshFolder -FolderPath "\General\Mobile Phones Demo" -Recurse | 
+    /// Get-IshFolderContent -VersionFilter "" -MetadataFilter $metadataFilter
+    /// </code>
+    /// <para>New-IshSession will submit into SessionState, so it can be reused by this cmdlet. The metadata filter will filter out source languages and the empty VersionFilter will return all versions of any object. The recursive folder allows you to control which area you do a check/conversion in, and give you progress as well.</para>
+    /// </example>
+    /// <example>
+    /// <code>
+    /// $ishSession = New-IshSession -WsBaseUrl "https://example.com/ISHWS/" -PSCredential "Admin"
     /// $ishSession.MetadataBatchSize = 100
     /// $DebugPreference = "Continue"
     /// Get-IshFolderContent -IshSession $ishSession -FolderPath "General\MyPublication\FolderWithManyTopics"
     /// </code>
-    /// <para>Retrieve content objects in smaller batches to avoid "heavy" WebService calls to the server. The progress could be seen in the debug messages</para>
+    /// <para>Retrieve the latest version of content objects in smaller batches to avoid "heavy" WebService calls to the server. The progress could be seen in the debug messages</para>
     /// </example>
-
     [Cmdlet(VerbsCommon.Get, "IshFolderContent", SupportsShouldProcess = false)]
     [OutputType(typeof(IshObject))]
     public sealed class GetIshFolderContent : FolderCmdlet

--- a/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.cs
+++ b/Source/ISHRemote/Trisoft.ISHRemote/Cmdlets/Folder/GetIshFolderContent.cs
@@ -119,7 +119,7 @@ namespace Trisoft.ISHRemote.Cmdlets.Folder
         [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = false, ParameterSetName = "FolderPathGroup")]
         [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = false, ParameterSetName = "BaseFolderGroup")]
         [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = false, ParameterSetName = "IshFolderGroup")]
-        [ValidateNotNullOrEmpty]
+        [ValidateNotNull]
         public string VersionFilter
         {
             get { return _versionFilter; }
@@ -155,7 +155,7 @@ namespace Trisoft.ISHRemote.Cmdlets.Folder
         /// <summary>
         /// Private field to store and provide defaults for non-mandatory parameters
         /// </summary>
-        private string _versionFilter = "";
+        private string _versionFilter = "latest";
         private string[] _languagesFilter = { };
         #endregion
 


### PR DESCRIPTION
Quick example of the change, so that all versions of the object are returned for empty VersionFilter